### PR TITLE
Remove unused date-fns import

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,3 @@
-import { set } from "date-fns"
-
 // catégories
 const URL_BASE = import.meta.env.VITE_API_URL
 const fetchCategories = async () => {


### PR DESCRIPTION
## Summary
- remove unused `set` import from `src/api.js`

## Testing
- `npm run lint` *(fails: ConfigError)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851e0a5195c832e93a04ee8966fd58a